### PR TITLE
Update application/libraries/Datatables.php

### DIFF
--- a/application/libraries/Datatables.php
+++ b/application/libraries/Datatables.php
@@ -287,7 +287,7 @@
         $mColArray = $this->columns;
 
       $sWhere = '';
-      $sSearch = $this->ci->db->escape($this->ci->input->post('sSearch'));
+      $sSearch = $this->ci->db->escape_like_str($this->ci->input->post('sSearch'));
 
       $mColArray = array_values(array_diff($mColArray, $this->unset_columns));
       $columns = array_values(array_diff($this->columns, $this->unset_columns));


### PR DESCRIPTION
As the conditional is being placed with a LIKE comparison function, 
the codeigniter documentation recommends using escape_like_str() 
(http://codeigniter.com/user_guide//database/queries.html). 
I was getting ' placed within the statement '%'xxx'%'...
