### PR TITLE
add group_by function in get_total_results function

### DIFF
--- a/application/libraries/Datatables.php
+++ b/application/libraries/Datatables.php
@@ -396,7 +396,10 @@
       foreach($this->where as $val)
         $this->ci->db->where($val[0], $val[1], $val[2]);
 
-      return $this->ci->db->count_all_results($this->table);
+      if($this->group_by != null)
+        $this->ci->db->group_by($this->group_by);
+      $q = $this->ci->db->get($this->table);
+      return $q->num_rows(); 
     }
 
     /**


### PR DESCRIPTION
the total result is not the same with the result rows when use group_by, so I added the group_by function and return $q->num_rows() instead of $this->ci->db->count_all_results($this->table)
