### PR TITLE
Missing $like array variable

### DIFF
--- a/application/libraries/Datatables.php
+++ b/application/libraries/Datatables.php
@@ -27,6 +27,7 @@
     private $joins          = array();
     private $columns        = array();
     private $where          = array();
+    private $like           = array();
     private $filter         = array();
     private $add_columns    = array();
     private $edit_columns   = array();


### PR DESCRIPTION
In line 418, there is a foreach loop that uses class variable $like but is not declared anywhere the source code.
