### PR TITLE
Minor unset_columns and display total changes

### DIFF
--- a/application/libraries/Datatables.php
+++ b/application/libraries/Datatables.php
@@ -219,7 +219,8 @@
     */
     public function unset_column($column)
     {
-      $this->unset_columns[] = $column;
+      $column=explode(',',$column);
+      $this->unset_columns=array_merge($this->unset_columns,$column);
       return $this;
     }
 
@@ -433,8 +434,8 @@
       foreach($this->like as $val)
         $this->ci->db->like($val[0], $val[1], $val[2]);
 
-      $query = $this->ci->db->get($this->table, NULL, NULL, FALSE);
-      return $query->num_rows(); 
+      $this->ci->db->from($this->table);
+      return $this->ci->db->count_all_results();
     }
 
     /**


### PR DESCRIPTION
My first pull request :)

Added the option to pass multiple coma-separated columns to
unset_columns.
Modified display total to use count_all_results (mysql COUNT(*)) instead
of num_rows that gets all the records and the performs the count in PHP.

TODO: I'm considering the option to add custom functions instead of match-replacements to edit_column and add_column to build more complex row formats.
