### PR TITLE
Ignore sSearch leading/trailing whitespace

### DIFF
--- a/application/libraries/Datatables.php
+++ b/application/libraries/Datatables.php
@@ -293,7 +293,7 @@
         $mColArray = $this->columns;
 
       $sWhere = '';
-      $sSearch = $this->ci->db->escape_like_str($this->ci->input->post('sSearch'));
+      $sSearch = $this->ci->db->escape_like_str(trim($this->ci->input->post('sSearch')));
       $mColArray = array_values(array_diff($mColArray, $this->unset_columns));
       $columns = array_values(array_diff($this->columns, $this->unset_columns));
 


### PR DESCRIPTION
Ignore leading and trailing whitespace when filtering Datatable.
