### PR TITLE
Fixes issue #84 - add_column greater than 9

### DIFF
--- a/application/libraries/Datatables.php
+++ b/application/libraries/Datatables.php
@@ -445,6 +445,9 @@
     private function exec_replace($custom_val, $row_data)
     {
       $replace_string = '';
+      
+      // Go through our array backwards, else $1 (foo) will replace $11, $12 etc with foo1, foo2 etc
+      $custom_val['replacement'] = array_reverse($custom_val['replacement'], true);
 
       if(isset($custom_val['replacement']) && is_array($custom_val['replacement']))
       {


### PR DESCRIPTION
If you use add_column, and attempt to pass more than 9 match_replacements (ie, $10, $11 etc), the exec_replace replacement function doesn't work. This is due to exec_replace running through each key in order, which causes $1 (foo) to also replace $11, $12 etc with foo1, foo2 etc.

Probably not the greatest solution, but it works