### PR TITLE
Corrects function arguments

### DIFF
--- a/application/libraries/Datatables.php
+++ b/application/libraries/Datatables.php
@@ -165,10 +165,10 @@
     * @param bool $backtick_protect
     * @return mixed
     */
-    public function where_in($key_condition, $val = NULL, $backtick_protect = TRUE)
+    public function where_in($key_condition, $val = NULL)
     {
-      $this->where_in[] = array($key_condition, $val, $backtick_protect);
-      $this->ci->db->where_in($key_condition, $val, $backtick_protect);
+      $this->where_in[] = array($key_condition, $val);
+      $this->ci->db->where_in($key_condition, $val);
       return $this;
     }
 
@@ -194,10 +194,10 @@
     * @param bool $backtick_protect
     * @return mixed
     */
-    public function like($key_condition, $val = NULL, $backtick_protect = TRUE)
+    public function like($key_condition, $val = NULL, $side = 'both')
     {
-      $this->like[] = array($key_condition, $val, $backtick_protect);
-      $this->ci->db->like($key_condition, $val, $backtick_protect);
+      $this->like[] = array($key_condition, $val, $side);
+      $this->ci->db->like($key_condition, $val, $side);
       return $this;
     }
 

--- a/application/libraries/Datatables.php
+++ b/application/libraries/Datatables.php
@@ -417,7 +417,7 @@
         $this->ci->db->or_where($val[0], $val[1], $val[2]);
         
       foreach($this->where_in as $val)
-        $this->ci->db->where_in($val[0], $val[1], $val[2]);
+        $this->ci->db->where_in($val[0], $val[1]);
 
       foreach($this->group_by as $val)
         $this->ci->db->group_by($val);


### PR DESCRIPTION
The where_in function doesn't have a third argument.
The like function's third argument is optional to control where the wildcard (%) is placed.