### PR TITLE
added set_count_column

### DIFF
--- a/application/libraries/Datatables.php
+++ b/application/libraries/Datatables.php
@@ -22,6 +22,7 @@
     private $ci;
     private $table;
     private $distinct;
+    private $count_column;
     private $group_by       = array();
     private $select         = array();
     private $joins          = array();
@@ -243,6 +244,18 @@
     }
 
     /**
+    * Sets the column used for counting improving performance
+    * 
+    * @param string $column
+    * @return mixed
+    */
+    public function set_count_column($column)
+    {
+      $this->count_column = $column;
+      return $this;
+    }   
+
+    /**
     * Builds all the necessary query segments and performs the main query based on results set from chained statements
     *
     * @param string $output
@@ -406,6 +419,9 @@
     {
       if($filtering)
         $this->get_filtering();
+
+      if(strlen($this->count_column) > 0)
+        $this->ci->db->select($this->count_column);
 
       foreach($this->joins as $val)
         $this->ci->db->join($val[0], $val[1], $val[2]);
@@ -604,8 +620,8 @@
         return '{' . join(',', $json) . '}';
       }
     }
-	
-	 /**
+  
+   /**
      * returns the sql statement of the last query run
      * @return type
      */


### PR DESCRIPTION
The default behaviour of 'get_total_results' uses all fields from the query to generate a count. This function allows you to specify a single field to use as a count and can in some cases dramatically reduce loading time.

https://github.com/IgnitedDatatables/Ignited-Datatables/issues/82