### PR TITLE
Update Datatables.php

### DIFF
--- a/application/libraries/Datatables.php
+++ b/application/libraries/Datatables.php
@@ -449,9 +449,12 @@
         $this->ci->db->distinct($this->distinct);
         $this->ci->db->select($this->columns);
       }
-
-      $query = $this->ci->db->get($this->table, NULL, NULL, FALSE);
-      return $query->num_rows();
+      $subquery = $this->ci->db->get_compiled_select($this->table);
+      $countingsql = "SELECT COUNT(*) FROM (" . $subquery . ") SqueryAux";
+      $query = $this->ci->db->query($countingsql);
+      $result = $query->row_array();
+      $count = $result['COUNT(*)'];
+      return $count;
     }
 
     /**


### PR DESCRIPTION
Big fix to get_total_results function.  This passed the years and nobody realised that this function was counting all the records on selects, consuming huge amounts of memory (sometimes throwing OUT OF MEMORY) when working with big tables, and giving the impression the pagination was not working.