### PR TITLE
Remove new lines from select column name

### DIFF
--- a/application/libraries/Datatables.php
+++ b/application/libraries/Datatables.php
@@ -65,6 +65,7 @@
     {
       foreach($this->explode(',', $columns) as $val)
       {
+	$val = trim(preg_replace('/\s+/', ' ', $val)); // Remove New Lines
         $column = trim(preg_replace('/(.*)\s+as\s+(\w*)/i', '$2', $val));
         $column = preg_replace('/.*\.(.*)/i', '$1', $column); // get name after `.`
         $this->columns[] =  $column;


### PR DESCRIPTION
When column are written in multiple lines, the `as` column name is not extracted properly. Example:
```
CASE
    WHEN is_dispatched = 1 THEN "dispatched"
    WHEN is_delivered = 1 THEN "delivered"
    ELSE "pending"
END AS status
```